### PR TITLE
feat(ci): add auto-merge for Dependabot minor/patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,56 @@
+
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Prevent multiple auto-merge workflows from running concurrently
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Get Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check update type
+        id: check
+        run: |
+          UPDATE_TYPE="${{ steps.metadata.outputs.update-type }}"
+          echo "Update type: $UPDATE_TYPE"
+
+          if [[ "$UPDATE_TYPE" == "version-update:semver-major" ]]; then
+            echo "Major update detected - skipping auto-merge"
+            echo "should_merge=false" >> $GITHUB_OUTPUT
+          else
+            echo "Minor or patch update detected - proceeding with auto-merge"
+            echo "should_merge=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Auto-approve PR
+        if: steps.check.outputs.should_merge == 'true'
+        run: |
+          gh pr review --approve "${{ github.event.pull_request.number }}" \
+            --body "Auto-approving ${{ steps.metadata.outputs.update-type }} update"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.check.outputs.should_merge == 'true'
+        run: |
+          gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -89,19 +89,28 @@ Dependabot automatically creates PRs for dependency updates:
 - **Schedule**: Every Monday
 - **Grouping**: Minor and patch updates grouped together, major updates separate
 - **Testing**: CI runs automatically on all Dependabot PRs
+- **Auto-merge**: Minor and patch updates merge automatically after CI passes
 
-### Reviewing Dependabot PRs
+### Auto-Merge Behavior
 
-**For patch and minor updates**:
-1. Check that CI passes (green checkmarks)
-2. Review changelog/release notes (linked in PR description)
-3. Merge if no breaking changes
+**Minor and patch updates** (automatic):
+1. Dependabot creates PR
+2. CI runs automatically
+3. If all checks pass, PR is auto-approved and merged
+4. No manual intervention needed
 
-**For major version updates**:
+**Major version updates** (manual review required):
 1. Review breaking changes carefully
 2. Test locally if needed
 3. Update code to handle breaking changes
-4. Merge when ready
+4. Manually approve and merge when ready
+
+### Reviewing Dependabot PRs
+
+You can still review auto-merge PRs before they merge:
+- View the PR while CI is running
+- Check changelog/release notes (linked in PR description)
+- If issues found, close the PR to prevent auto-merge
 
 ### Skipping Updates
 If an update isn't needed:


### PR DESCRIPTION
## Summary
Adds automatic approval and merging for Dependabot PRs containing minor and patch version updates after all CI checks pass.

## Changes

### Workflow Features
- **Secure**: Uses `pull_request_target` with proper permissions
- **Selective**: Only auto-merges minor/patch updates (major requires manual review)
- **Safe**: Waits for all required CI checks to pass before merging
- **Concurrent-safe**: Prevents race conditions with concurrency control
- **Cancel-aware**: Cancels old workflows when PR updates (e.g., rebase)
- **Observable**: Clear logging and approval messages

### Documentation
- Updated CONTRIBUTING.md to explain auto-merge behavior
- Clarified difference between auto-merged and manual review processes

## Workflow Behavior

**For minor/patch updates:**
1. Dependabot creates PR
2. Workflow auto-approves with message showing update type
3. Enables auto-merge (queued until CI passes)
4. PR automatically merges when all checks are green

**For major updates:**
1. Dependabot creates PR
2. Workflow skips (logs "Major update detected - skipping auto-merge")
3. Requires manual review and merge

## Testing

This workflow will be tested when:
- Dependabot creates its next minor/patch update PR
- Can also be manually tested by creating a test Dependabot PR

## Benefits
- Reduces manual maintenance overhead
- Ensures updates are tested before merging
- Maintains safety through CI validation
- Keeps dependencies up-to-date automatically

Closes #11