### PR TITLE
Improve code quality across E2E and backend packages

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,4 @@
-
+name: Dependabot Auto-Merge
 
 on:
   pull_request_target:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -9,6 +9,12 @@ def client() -> TestClient:
     return TestClient(app)
 
 
+def test_root_endpoint(client: TestClient) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello World"}
+
+
 def test_say_hello_empty_name(client: TestClient) -> None:
     response = client.get("/hello/")
     assert response.status_code == 404

--- a/e2e/features/environment.py
+++ b/e2e/features/environment.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from playwright.sync_api import sync_playwright
 
-from utils import sanitize_filename
+from utils import ScreenshotMode, sanitize_filename
 
 
 def before_all(context) -> None:
@@ -44,17 +44,9 @@ def after_scenario(context, scenario) -> None:
 
 def after_step(context, step) -> None:
     """Take screenshot after each step if configured."""
-    # Screenshot modes:
-    # - SCREENSHOT_STEPS=all: Capture all steps
-    # - SCREENSHOT_STEPS=then: Capture only "Then" steps (default)
-    # - SCREENSHOT_STEPS=false: No step screenshots
-    screenshot_mode = os.getenv("SCREENSHOT_STEPS", "then").lower()
+    screenshot_mode = ScreenshotMode.from_env(os.getenv("SCREENSHOT_STEPS"))
 
-    should_screenshot = screenshot_mode == "all" or (
-        screenshot_mode == "then" and step.keyword.strip().lower() == "then"
-    )
-
-    if should_screenshot:
+    if screenshot_mode.should_capture(step.keyword.strip()):
         # Save to screenshots directory
         step_name = f"{context.scenario_name}_{step.keyword.strip()}_{step.name}"
         screenshot_name = f"{sanitize_filename(step_name)}.png"

--- a/e2e/features/environment.py
+++ b/e2e/features/environment.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from playwright.sync_api import sync_playwright
 
+from utils import sanitize_filename
+
 
 def before_all(context) -> None:
     """Setup before all tests."""
@@ -32,25 +34,12 @@ def after_scenario(context, scenario) -> None:
     """Cleanup after each scenario."""
     # Take screenshot on failure
     if scenario.status == "failed":
-        screenshot_name = f"{_sanitize_filename(context.scenario_name)}_FAILED.png"
+        screenshot_name = f"{sanitize_filename(context.scenario_name)}_FAILED.png"
         screenshot_path = context.screenshots_dir / screenshot_name
         context.page.screenshot(path=str(screenshot_path))
         print(f"Screenshot saved: {screenshot_path}")
 
     context.page.close()
-
-
-def _sanitize_filename(name: str) -> str:
-    """Sanitize filename by removing invalid characters."""
-    # Replace invalid characters with underscores
-    invalid_chars = '":<>|*?\r\n'
-    for char in invalid_chars:
-        name = name.replace(char, "_")
-    # Replace spaces with underscores and collapse multiple underscores
-    name = name.replace(" ", "_")
-    while "__" in name:
-        name = name.replace("__", "_")
-    return name
 
 
 def after_step(context, step) -> None:
@@ -68,7 +57,7 @@ def after_step(context, step) -> None:
     if should_screenshot:
         # Save to screenshots directory
         step_name = f"{context.scenario_name}_{step.keyword.strip()}_{step.name}"
-        screenshot_name = f"{_sanitize_filename(step_name)}.png"
+        screenshot_name = f"{sanitize_filename(step_name)}.png"
         screenshot_path = context.screenshots_dir / screenshot_name
         context.page.screenshot(path=str(screenshot_path))
         print(f"Step screenshot saved: {screenshot_path}")

--- a/e2e/features/steps/greeting_steps.py
+++ b/e2e/features/steps/greeting_steps.py
@@ -5,28 +5,33 @@ use_step_matcher("re")
 
 @given("the application is running")
 def step_app_running(context) -> None:
+    """Navigate to the app and wait for initial load to complete."""
     context.page.goto("http://localhost:4200")
     context.page.wait_for_load_state("networkidle")
 
 
 @when("I click the greeting button without entering a name")
 def step_click_button_no_name(context) -> None:
+    """Click the greet button with an empty name field to trigger the default greeting."""
     context.page.click("#greetButton")
     context.page.wait_for_selector("#greetingResult")
 
 
 @when('I enter "(?P<name>.+)" as my name')
 def step_enter_name(context, name: str) -> None:
+    """Fill the name input field with the provided value."""
     context.page.fill("#nameInput", name)
 
 
 @when("I click the greeting button")
 def step_click_button(context) -> None:
+    """Click the greet button and wait for the API response to render."""
     context.page.click("#greetButton")
     context.page.wait_for_selector("#greetingResult")
 
 
 @then('I should see "(?P<message>.+)" on the page')
 def step_check_message(context, message: str) -> None:
+    """Assert that the greeting result element displays the expected message."""
     greeting_text = context.page.text_content("#greetingResult")
     assert greeting_text == message, f"Expected '{message}', got '{greeting_text}'"

--- a/e2e/generate_pdf_report.py
+++ b/e2e/generate_pdf_report.py
@@ -26,6 +26,8 @@ from reportlab.platypus import (
     TableStyle,
 )
 
+from utils import sanitize_filename
+
 
 class TestReportGenerator:
     def __init__(self, json_path: Path, screenshots_dir: Path, output_path: Path):
@@ -145,25 +147,13 @@ class TestReportGenerator:
         self.story.append(summary_table)
         self.story.append(PageBreak())
 
-    def _sanitize_filename(self, name: str) -> str:
-        """Sanitize filename by removing invalid characters."""
-        # Replace invalid characters with underscores
-        invalid_chars = '":<>|*?\r\n'
-        for char in invalid_chars:
-            name = name.replace(char, "_")
-        # Replace spaces with underscores and collapse multiple underscores
-        name = name.replace(" ", "_")
-        while "__" in name:
-            name = name.replace("__", "_")
-        return name
-
     def _find_screenshot(
         self, scenario_name: str, step_keyword: str, step_name: str
     ) -> Path | None:
         """Find screenshot for a step."""
         # Match the naming pattern from environment.py
         step_screenshot = f"{scenario_name}_{step_keyword}_{step_name}"
-        sanitized = self._sanitize_filename(step_screenshot)
+        sanitized = sanitize_filename(step_screenshot)
 
         for ext in [".png", ".jpg", ".jpeg"]:
             screenshot_path = self.screenshots_dir / f"{sanitized}{ext}"

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -9,7 +9,11 @@ dependencies = [
     "reportlab>=4.0.0",
     "pillow>=11.1.0",
     "ruff>=0.9.0",
+    "pytest>=8.3.4",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 100

--- a/e2e/tests/test_utils.py
+++ b/e2e/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils import sanitize_filename
+from utils import ScreenshotMode, sanitize_filename
 
 
 class TestSanitizeFilename:
@@ -42,3 +42,35 @@ class TestSanitizeFilename:
     )
     def test_real_world_scenario_names(self, input_name: str, expected: str) -> None:
         assert sanitize_filename(input_name) == expected
+
+
+class TestScreenshotMode:
+    def test_enum_values(self) -> None:
+        assert ScreenshotMode.ALL.value == "all"
+        assert ScreenshotMode.THEN.value == "then"
+        assert ScreenshotMode.DISABLED.value == "false"
+
+    def test_from_env_defaults_to_then(self) -> None:
+        assert ScreenshotMode.from_env(None) is ScreenshotMode.THEN
+
+    def test_from_env_case_insensitive(self) -> None:
+        assert ScreenshotMode.from_env("ALL") is ScreenshotMode.ALL
+        assert ScreenshotMode.from_env("Then") is ScreenshotMode.THEN
+        assert ScreenshotMode.from_env("FALSE") is ScreenshotMode.DISABLED
+
+    def test_from_env_invalid_defaults_to_then(self) -> None:
+        assert ScreenshotMode.from_env("invalid") is ScreenshotMode.THEN
+
+    def test_should_capture_all_mode(self) -> None:
+        assert ScreenshotMode.ALL.should_capture("given") is True
+        assert ScreenshotMode.ALL.should_capture("then") is True
+        assert ScreenshotMode.ALL.should_capture("when") is True
+
+    def test_should_capture_then_mode(self) -> None:
+        assert ScreenshotMode.THEN.should_capture("then") is True
+        assert ScreenshotMode.THEN.should_capture("given") is False
+        assert ScreenshotMode.THEN.should_capture("when") is False
+
+    def test_should_capture_disabled_mode(self) -> None:
+        assert ScreenshotMode.DISABLED.should_capture("then") is False
+        assert ScreenshotMode.DISABLED.should_capture("given") is False

--- a/e2e/tests/test_utils.py
+++ b/e2e/tests/test_utils.py
@@ -1,0 +1,44 @@
+import pytest
+
+from utils import sanitize_filename
+
+
+class TestSanitizeFilename:
+    def test_replaces_spaces_with_underscores(self) -> None:
+        assert sanitize_filename("hello world") == "hello_world"
+
+    def test_replaces_invalid_characters(self) -> None:
+        assert sanitize_filename('file"name') == "file_name"
+        assert sanitize_filename("file:name") == "file_name"
+        assert sanitize_filename("file<name>") == "file_name_"
+        assert sanitize_filename("file|name") == "file_name"
+        assert sanitize_filename("file*name") == "file_name"
+        assert sanitize_filename("file?name") == "file_name"
+
+    def test_collapses_multiple_underscores(self) -> None:
+        assert sanitize_filename("file   name") == "file_name"
+        assert sanitize_filename("file:::name") == "file_name"
+
+    def test_handles_newlines(self) -> None:
+        assert sanitize_filename("file\nname") == "file_name"
+        assert sanitize_filename("file\r\nname") == "file_name"
+
+    def test_preserves_valid_characters(self) -> None:
+        assert sanitize_filename("valid_filename-123.png") == "valid_filename-123.png"
+
+    def test_handles_empty_string(self) -> None:
+        assert sanitize_filename("") == ""
+
+    def test_handles_mixed_invalid_characters(self) -> None:
+        assert sanitize_filename('a "b" <c> :d:') == "a_b_c_d_"
+
+    @pytest.mark.parametrize(
+        ("input_name", "expected"),
+        [
+            ("Scenario_Then_check_message", "Scenario_Then_check_message"),
+            ("My Scenario:Step 1", "My_Scenario_Step_1"),
+            ("test<with>brackets", "test_with_brackets"),
+        ],
+    )
+    def test_real_world_scenario_names(self, input_name: str, expected: str) -> None:
+        assert sanitize_filename(input_name) == expected

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -1,5 +1,33 @@
 """Shared utilities for E2E test infrastructure."""
 
+from enum import Enum
+
+
+class ScreenshotMode(Enum):
+    """Controls which BDD steps trigger screenshot capture."""
+
+    ALL = "all"
+    THEN = "then"
+    DISABLED = "false"
+
+    @classmethod
+    def from_env(cls, value: str | None) -> ScreenshotMode:
+        """Parse an environment variable value into a ScreenshotMode."""
+        if value is None:
+            return cls.THEN
+        try:
+            return cls(value.lower())
+        except ValueError:
+            return cls.THEN
+
+    def should_capture(self, step_keyword: str) -> bool:
+        """Determine whether a screenshot should be taken for the given step keyword."""
+        if self is ScreenshotMode.ALL:
+            return True
+        if self is ScreenshotMode.THEN:
+            return step_keyword.lower() == "then"
+        return False
+
 
 def sanitize_filename(name: str) -> str:
     """Sanitize filename by removing invalid characters."""

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -1,0 +1,12 @@
+"""Shared utilities for E2E test infrastructure."""
+
+
+def sanitize_filename(name: str) -> str:
+    """Sanitize filename by removing invalid characters."""
+    invalid_chars = '":<>|*?\r\n'
+    for char in invalid_chars:
+        name = name.replace(char, "_")
+    name = name.replace(" ", "_")
+    while "__" in name:
+        name = name.replace("__", "_")
+    return name

--- a/e2e/uv.lock
+++ b/e2e/uv.lock
@@ -97,6 +97,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "keystone-e2e"
 version = "0.1.0"
 source = { virtual = "." }
@@ -104,6 +113,7 @@ dependencies = [
     { name = "behave" },
     { name = "pillow" },
     { name = "playwright" },
+    { name = "pytest" },
     { name = "reportlab" },
     { name = "ruff" },
 ]
@@ -113,8 +123,18 @@ requires-dist = [
     { name = "behave", specifier = ">=1.2.6" },
     { name = "pillow", specifier = ">=11.1.0" },
     { name = "playwright", specifier = ">=1.49.1" },
+    { name = "pytest", specifier = ">=8.3.4" },
     { name = "reportlab", specifier = ">=4.0.0" },
     { name = "ruff", specifier = ">=0.9.0" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
 ]
 
 [[package]]
@@ -192,6 +212,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -201,6 +230,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/03/1fd98d5841cd7964a27d729ccf2199602fe05eb7a405c1462eb7277945ed/pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37", size = 31250, upload-time = "2025-03-17T18:53:15.955Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/4d/b9add7c84060d4c1906abe9a7e5359f2a60f7a9a4f67268b2766673427d8/pyee-13.0.0-py3-none-any.whl", hash = "sha256:48195a3cddb3b1515ce0695ed76036b5ccc2ef3a9f963ff9f77aec0139845498", size = 15730, upload-time = "2025-03-17T18:53:14.532Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Addresses code quality improvements identified across the E2E and backend packages, resolving a DRY violation, magic strings, a test coverage gap, and missing documentation.

## Implementation

- **Extract shared utility** — Moved duplicated `sanitize_filename` from `environment.py` and `generate_pdf_report.py` into a shared `e2e/utils.py` module with 10 unit tests
- **Type-safe screenshot modes** — Replaced bare string comparisons (`"all"`, `"then"`, `"false"`) with a `ScreenshotMode` enum that encapsulates parsing and capture logic, with 7 unit tests
- **Backend test coverage** — Added missing `GET /` root endpoint test, bringing backend coverage to 100%
- **Step definition docs** — Added docstrings to all BDD step functions in `greeting_steps.py`

## Test plan

- [ ] `cd e2e && uv run pytest tests/ -v` — 17 utils tests pass
- [ ] `cd backend && uv run pytest -v` — 3 backend tests pass (100% coverage)
- [ ] `cd e2e && uv run ruff check . && uv run ruff format --check .` — no lint/format issues
- [ ] `cd backend && uv run ruff check . && uv run ruff format --check .` — no lint/format issues
- [ ] E2E tests still pass with `just e2e-headless`

Closes #21