### PR TITLE
Address testing gaps across frontend, E2E, and CI

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -62,4 +62,5 @@ addopts = [
     "--cov-report=json",
     "--cov-report=lcov",
     "--cov-branch",
+    "--cov-fail-under=80",
 ]

--- a/e2e/features/greeting.feature
+++ b/e2e/features/greeting.feature
@@ -13,3 +13,17 @@ Feature: Greeting Application
     When I enter "Alice" as my name
     And I click the greeting button
     Then I should see "Hello Alice" on the page
+
+  Scenario: Get greeting with special characters
+    Given the application is running
+    When I enter "José O'Brien" as my name
+    And I click the greeting button
+    Then I should see "Hello José O'Brien" on the page
+
+  Scenario: Get multiple greetings in sequence
+    Given the application is running
+    When I click the greeting button without entering a name
+    Then I should see "Hello World" on the page
+    When I enter "Bob" as my name
+    And I click the greeting button
+    Then I should see "Hello Bob" on the page

--- a/e2e/features/steps/greeting_steps.py
+++ b/e2e/features/steps/greeting_steps.py
@@ -13,7 +13,8 @@ def step_app_running(context) -> None:
 @when("I click the greeting button without entering a name")
 def step_click_button_no_name(context) -> None:
     """Click the greet button with an empty name field to trigger the default greeting."""
-    context.page.click("#greetButton")
+    with context.page.expect_response(lambda r: "/api" in r.url):
+        context.page.click("#greetButton")
     context.page.wait_for_selector("#greetingResult")
 
 
@@ -26,7 +27,8 @@ def step_enter_name(context, name: str) -> None:
 @when("I click the greeting button")
 def step_click_button(context) -> None:
     """Click the greet button and wait for the API response to render."""
-    context.page.click("#greetButton")
+    with context.page.expect_response(lambda r: "/api" in r.url):
+        context.page.click("#greetButton")
     context.page.wait_for_selector("#greetingResult")
 
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -74,7 +74,13 @@
           "builder": "@angular/build:unit-test",
           "options": {
             "coverage": true,
-            "coverageReporters": ["text", "html", "json", "lcov"]
+            "coverageReporters": ["text", "html", "json", "lcov"],
+            "coverageThresholds": {
+              "statements": 80,
+              "branches": 75,
+              "functions": 80,
+              "lines": 80
+            }
           }
         }
       }

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -9,8 +9,14 @@
       class="name-input"
       id="nameInput"
     />
-    <button (click)="getGreeting()" class="greet-button" id="greetButton">Get Greeting</button>
+    <button (click)="getGreeting()" class="greet-button" id="greetButton" [disabled]="loading()">
+      Get Greeting
+    </button>
   </div>
+
+  @if (loading()) {
+    <div class="loading-indicator" id="loadingIndicator">Loading...</div>
+  }
 
   @if (error()) {
     <div class="error-message" id="errorMessage">{{ error() }}</div>

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -12,6 +12,10 @@
     <button (click)="getGreeting()" class="greet-button" id="greetButton">Get Greeting</button>
   </div>
 
+  @if (error()) {
+    <div class="error-message" id="errorMessage">{{ error() }}</div>
+  }
+
   @if (greeting()) {
     <div class="greeting-result" id="greetingResult">{{ greeting() }}</div>
   }

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -1,17 +1,33 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import type { WritableSignal } from '@angular/core';
 import { App } from './app';
 
+interface AppSignals {
+  name: WritableSignal<string>;
+  greeting: WritableSignal<string>;
+}
+
 describe('App', () => {
+  let httpTesting: HttpTestingController;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
+
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
   });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(App);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
   it('should render title', async () => {
@@ -19,5 +35,65 @@ describe('App', () => {
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('h1')?.textContent).toContain('Keystone Greeting App');
+  });
+
+  it('should call GET /api/ when name is empty and set greeting', () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance;
+
+    app.getGreeting();
+
+    const req = httpTesting.expectOne('/api/');
+    expect(req.request.method).toBe('GET');
+    req.flush({ message: 'Hello World' });
+
+    expect((app as unknown as AppSignals).greeting()).toBe('Hello World');
+  });
+
+  it('should call GET /api/hello/{name} when name is set and set greeting', () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance;
+    (app as unknown as AppSignals).name.set('Alice');
+
+    app.getGreeting();
+
+    const req = httpTesting.expectOne('/api/hello/Alice');
+    expect(req.request.method).toBe('GET');
+    req.flush({ message: 'Hello Alice' });
+
+    expect((app as unknown as AppSignals).greeting()).toBe('Hello Alice');
+  });
+
+  it('should trigger getGreeting on button click', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const spy = vi.spyOn(fixture.componentInstance, 'getGreeting').mockImplementation(vi.fn());
+    const compiled = fixture.nativeElement as HTMLElement;
+    const button = compiled.querySelector<HTMLButtonElement>('#greetButton');
+    expect(button).toBeTruthy();
+    button?.click();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should render greeting result when greeting is set', () => {
+    const fixture = TestBed.createComponent(App);
+    (fixture.componentInstance as unknown as AppSignals).greeting.set('Hello World');
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const result = compiled.querySelector('#greetingResult');
+    expect(result).toBeTruthy();
+    expect(result?.textContent).toBe('Hello World');
+  });
+
+  it('should not render greeting result when greeting is empty', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const result = compiled.querySelector('#greetingResult');
+    expect(result).toBeNull();
   });
 });

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -7,6 +7,7 @@ import { App } from './app';
 interface AppSignals {
   name: WritableSignal<string>;
   greeting: WritableSignal<string>;
+  error: WritableSignal<string>;
 }
 
 describe('App', () => {
@@ -95,5 +96,42 @@ describe('App', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     const result = compiled.querySelector('#greetingResult');
     expect(result).toBeNull();
+  });
+
+  it('should set error signal on HTTP failure', () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance;
+
+    app.getGreeting();
+
+    const req = httpTesting.expectOne('/api/');
+    req.flush('Server Error', { status: 500, statusText: 'Internal Server Error' });
+
+    expect((app as unknown as AppSignals).error()).toBe('Failed to fetch greeting');
+  });
+
+  it('should clear error on new request', () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance;
+    const signals = app as unknown as AppSignals;
+    signals.error.set('Previous error');
+
+    app.getGreeting();
+
+    expect(signals.error()).toBe('');
+
+    const req = httpTesting.expectOne('/api/');
+    req.flush({ message: 'Hello World' });
+  });
+
+  it('should render error message when error is set', () => {
+    const fixture = TestBed.createComponent(App);
+    (fixture.componentInstance as unknown as AppSignals).error.set('Something went wrong');
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const errorEl = compiled.querySelector('#errorMessage');
+    expect(errorEl).toBeTruthy();
+    expect(errorEl?.textContent).toContain('Something went wrong');
   });
 });

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -8,6 +8,7 @@ interface AppSignals {
   name: WritableSignal<string>;
   greeting: WritableSignal<string>;
   error: WritableSignal<string>;
+  loading: WritableSignal<boolean>;
 }
 
 describe('App', () => {
@@ -122,6 +123,56 @@ describe('App', () => {
 
     const req = httpTesting.expectOne('/api/');
     req.flush({ message: 'Hello World' });
+  });
+
+  it('should set loading true during request and false after response', () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance;
+    const signals = app as unknown as AppSignals;
+
+    app.getGreeting();
+    expect(signals.loading()).toBe(true);
+
+    const req = httpTesting.expectOne('/api/');
+    req.flush({ message: 'Hello World' });
+
+    expect(signals.loading()).toBe(false);
+  });
+
+  it('should set loading false after error', () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance;
+    const signals = app as unknown as AppSignals;
+
+    app.getGreeting();
+    expect(signals.loading()).toBe(true);
+
+    const req = httpTesting.expectOne('/api/');
+    req.flush('Server Error', { status: 500, statusText: 'Internal Server Error' });
+
+    expect(signals.loading()).toBe(false);
+  });
+
+  it('should disable button while loading', () => {
+    const fixture = TestBed.createComponent(App);
+    const signals = fixture.componentInstance as unknown as AppSignals;
+
+    signals.loading.set(true);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const button = compiled.querySelector<HTMLButtonElement>('#greetButton');
+    expect(button?.disabled).toBe(true);
+  });
+
+  it('should render loading indicator while loading', () => {
+    const fixture = TestBed.createComponent(App);
+    (fixture.componentInstance as unknown as AppSignals).loading.set(true);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const indicator = compiled.querySelector('#loadingIndicator');
+    expect(indicator).toBeTruthy();
   });
 
   it('should render error message when error is set', () => {

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -14,19 +14,23 @@ export class App {
   protected name = signal('');
   protected greeting = signal('');
   protected error = signal('');
+  protected loading = signal(false);
 
   private readonly http = inject(HttpClient);
 
   getGreeting(): void {
     this.error.set('');
+    this.loading.set(true);
     const nameValue = this.name();
     const url = nameValue ? `/api/hello/${nameValue}` : '/api/';
     this.http.get<{ message: string }>(url).subscribe({
       next: (response) => {
         this.greeting.set(response.message);
+        this.loading.set(false);
       },
       error: () => {
         this.error.set('Failed to fetch greeting');
+        this.loading.set(false);
       },
     });
   }

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -13,19 +13,21 @@ export class App {
   protected readonly title = signal('Keystone Greeting App');
   protected name = signal('');
   protected greeting = signal('');
+  protected error = signal('');
 
   private readonly http = inject(HttpClient);
 
   getGreeting(): void {
+    this.error.set('');
     const nameValue = this.name();
-    if (!nameValue) {
-      this.http.get<{ message: string }>('/api/').subscribe((response) => {
+    const url = nameValue ? `/api/hello/${nameValue}` : '/api/';
+    this.http.get<{ message: string }>(url).subscribe({
+      next: (response) => {
         this.greeting.set(response.message);
-      });
-    } else {
-      this.http.get<{ message: string }>(`/api/hello/${nameValue}`).subscribe((response) => {
-        this.greeting.set(response.message);
-      });
-    }
+      },
+      error: () => {
+        this.error.set('Failed to fetch greeting');
+      },
+    });
   }
 }


### PR DESCRIPTION
## Summary

- **Frontend unit tests:** Rewrote `app.spec.ts` with `HttpClientTesting` — 14 tests covering HTTP routing, signal state, button binding, conditional rendering, error handling, and loading state (up from 2 basic tests)
- **Error handling:** Added `error` signal and subscribe error callbacks so HTTP failures display a message instead of being silently swallowed
- **Loading state:** Added `loading` signal with indicator text and disabled button during requests to prevent duplicate submissions
- **E2E edge cases:** Added special character (`José O'Brien`) and sequential greeting scenarios to `greeting.feature`
- **Coverage thresholds:** Backend enforces 80% via `--cov-fail-under`, frontend enforces 80% statements/functions/lines and 75% branches via `coverageThresholds`

## Test plan

- [x] `cd frontend && npm test` — 14 tests pass, coverage thresholds met
- [x] `cd backend && uv run pytest` — 3 tests pass, 100% coverage, threshold met
- [x] `cd e2e && uv run ruff check .` — lint clean
- [x] `cd frontend && npm run lint` — lint clean
- [x] `just e2e-headless` — verify new E2E scenarios pass against running services